### PR TITLE
Add entries for IntelliJ in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,7 @@ target
 .tern-project
 /.apt_generated/
 /.apt_generated_tests/
+
+# IntelliJ
+.idea
+**/*.iml


### PR DESCRIPTION
Added .gitignore entries for IntelliJ to prevent unwanted files in future development

Signed-off-by: Jason Pollard <jpollard91@msn.com>