### PR TITLE
Use actual war build instead of programmatic micro archive for ws tests

### DIFF
--- a/focused/pom.xml
+++ b/focused/pom.xml
@@ -220,6 +220,7 @@
                     <groupId>org.omnifaces.arquillian</groupId>
                     <artifactId>glassfish-client-ee10</artifactId>
                     <version>1.3</version>
+                    <scope>test</scope>
                 </dependency>
 
                 <!-- 
@@ -240,7 +241,6 @@
                     
                     <!-- Download and unzip GlassFish -->
                     <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-dependency-plugin</artifactId>
                         <executions>
                             <execution>
@@ -268,8 +268,17 @@
                     </plugin>
                     
                     <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <systemPropertyVariables>
+                                <glassfish.home>${session.executionRootDirectory}/target/glassfish7</glassfish.home>
+                                <glassfish.enableDerby>true</glassfish.enableDerby>
+                            </systemPropertyVariables>
+                        </configuration>
+                    </plugin>
+                    
+                    <plugin>
+                        <artifactId>maven-failsafe-plugin</artifactId>
                         <configuration>
                             <systemPropertyVariables>
                                 <glassfish.home>${session.executionRootDirectory}/target/glassfish7</glassfish.home>

--- a/focused/websocket/annotatedClientEndpoint/src/test/java/jakartaee/examples/websocket/annotatedclientendpoint/AnnotatedClientEndpointIT.java
+++ b/focused/websocket/annotatedClientEndpoint/src/test/java/jakartaee/examples/websocket/annotatedclientendpoint/AnnotatedClientEndpointIT.java
@@ -1,5 +1,5 @@
 /*
- * Permission to use, copy, modify, and/or distribute this software for any 
+ * Permission to use, copy, modify, and/or distribute this software for any
  * purpose with or without fee is hereby granted.
  *
  * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR(S) DISCLAIMS ALL WARRANTIES
@@ -10,39 +10,37 @@
  * OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
  * CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
-package jakartaee.examples.websocket.onclose;
+package jakartaee.examples.websocket.annotatedclientendpoint;
 
+import static org.junit.Assert.assertEquals;
 
-import java.io.File;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URL;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
-import jakarta.websocket.ClientEndpoint;
-import jakarta.websocket.OnClose;
-import jakarta.websocket.OnMessage;
-import jakarta.websocket.Session;
-import org.jboss.arquillian.junit.Arquillian;
+
 import org.glassfish.tyrus.client.ClientManager;
-import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
-import static org.jboss.shrinkwrap.api.ShrinkWrap.create;
-import org.jboss.shrinkwrap.api.spec.WebArchive;
-import static org.junit.Assert.assertTrue;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import jakarta.websocket.ClientEndpoint;
+import jakarta.websocket.OnMessage;
+import jakarta.websocket.OnOpen;
+import jakarta.websocket.Session;
+import jakartaee.examples.utils.ITBase;
+
 /**
- * A JUnit test for the @OnError example.
+ * An annotated ClientEndpoint for the annotated ClientEndpoint example.
  *
  * @author Manfred Riem (mriem@manorrock.com)
  */
 @ClientEndpoint
 @RunWith(Arquillian.class)
-
-public class OnCloseEndpointTest {
+public class AnnotatedClientEndpointIT extends ITBase {
 
     /**
      * Stores the base URL.
@@ -61,21 +59,6 @@ public class OnCloseEndpointTest {
     private CountDownLatch countDown = new CountDownLatch(1);
 
     /**
-     * Create the deployment web archive.
-     *
-     * @return the deployment web archive.
-     */
-    @Deployment
-    public static WebArchive createDeployment() {
-        return create(WebArchive.class).addClasses(
-                OnCloseEndpoint.class).
-                addAsWebResource(new File("src/main/webapp/index.xhtml")).
-                addAsWebInfResource(new File("src/main/webapp/WEB-INF/web.xml")).
-                addAsWebInfResource(new File("src/main/webapp/WEB-INF/beans.xml"))
-                ;
-    }
-
-    /**
      * Get the buffer.
      *
      * @return the buffer.
@@ -83,28 +66,30 @@ public class OnCloseEndpointTest {
     public String getBuffer() {
         return buffer.toString();
     }
-    
+
+    /**
+     * Handle the on open event.
+     *
+     * @param session the session.
+     */
+    @OnOpen
+    public void onOpen(Session session) {
+        try {
+            session.getBasicRemote().sendText("ECHO");
+        } catch (IOException ioe) {
+            buffer.append(ioe.getMessage());
+        }
+    }
+
     /**
      * Handle the text message.
      *
      * @param session the session.
      * @param message the message.
-     * @throws Exception when a serious error occurs.
      */
     @OnMessage
-    public void onMessage(Session session, String message) throws Exception {
-        session.getBasicRemote().sendText(message);
-    }
-    
-    /**
-     * Handle the onClose.
-     *
-     * @param session the session.
-     * @throws IOException when an I/O error occurs.
-     */
-    @OnClose
-    public void onClose(Session session) throws IOException {
-        buffer.append("Closing connection");
+    public void onMessage(Session session, String message) {
+        buffer.append(message);
         countDown.countDown();
     }
 
@@ -117,13 +102,15 @@ public class OnCloseEndpointTest {
     @RunAsClient
     public void testClientEndpoint() throws Exception {
         countDown = new CountDownLatch(1);
+
         ClientManager client = ClientManager.createClient();
         StringBuilder wsUrl = new StringBuilder();
         wsUrl.append("ws://").append(baseUrl.getHost()).append(":").
                 append(baseUrl.getPort()).append(baseUrl.getPath()).append("echo");
         client.connectToServer(this, new URI(wsUrl.toString()));
-        countDown.await(100, TimeUnit.SECONDS);
-        System.out.println(buffer.toString());
-        assertTrue(buffer.toString().contains("Closing connection"));
+
+        countDown.await(10, TimeUnit.SECONDS);
+
+        assertEquals("ECHO", buffer.toString());
     }
 }

--- a/focused/websocket/annotatedServerEndpoint/src/test/java/jakartaee/examples/websocket/annotatedserverendpoint/AnnotatedServerEndpointIT.java
+++ b/focused/websocket/annotatedServerEndpoint/src/test/java/jakartaee/examples/websocket/annotatedserverendpoint/AnnotatedServerEndpointIT.java
@@ -1,5 +1,5 @@
 /*
- * Permission to use, copy, modify, and/or distribute this software for any 
+ * Permission to use, copy, modify, and/or distribute this software for any
  * purpose with or without fee is hereby granted.
  *
  * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR(S) DISCLAIMS ALL WARRANTIES
@@ -13,26 +13,26 @@
 package jakartaee.examples.websocket.annotatedserverendpoint;
 
 
-import java.io.File;
+import static org.junit.Assert.assertEquals;
+
 import java.io.IOException;
 import java.net.URI;
 import java.net.URL;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+
+import org.glassfish.tyrus.client.ClientManager;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
 import jakarta.websocket.ClientEndpoint;
 import jakarta.websocket.OnMessage;
 import jakarta.websocket.OnOpen;
 import jakarta.websocket.Session;
-import org.jboss.arquillian.junit.Arquillian;
-import org.glassfish.tyrus.client.ClientManager;
-import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.container.test.api.RunAsClient;
-import org.jboss.arquillian.test.api.ArquillianResource;
-import static org.jboss.shrinkwrap.api.ShrinkWrap.create;
-import org.jboss.shrinkwrap.api.spec.WebArchive;
-import static org.junit.Assert.assertEquals;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import jakartaee.examples.utils.ITBase;
 
 /**
  * An annotated ClientEndpoint for the annotated ClientEndpoint example.
@@ -41,8 +41,7 @@ import org.junit.runner.RunWith;
  */
 @ClientEndpoint
 @RunWith(Arquillian.class)
-
-public class AnnotatedServerEndpointTest {
+public class AnnotatedServerEndpointIT extends ITBase {
 
     /**
      * Stores the base URL.
@@ -59,21 +58,6 @@ public class AnnotatedServerEndpointTest {
      * Stores our countdown latch.
      */
     private CountDownLatch countDown = new CountDownLatch(1);
-
-    /**
-     * Create the deployment web archive.
-     *
-     * @return the deployment web archive.
-     */
-    @Deployment
-    public static WebArchive createDeployment() {
-        return create(WebArchive.class).addClasses(
-                AnnotatedServerEndpoint.class).
-                addAsWebResource(new File("src/main/webapp/index.xhtml")).
-                addAsWebInfResource(new File("src/main/webapp/WEB-INF/web.xml")).
-                addAsWebInfResource(new File("src/main/webapp/WEB-INF/beans.xml"))
-                ;
-    }
 
     /**
      * Get the buffer.
@@ -119,11 +103,18 @@ public class AnnotatedServerEndpointTest {
     @RunAsClient
     public void testClientEndpoint() throws Exception {
         countDown = new CountDownLatch(1);
+
         ClientManager client = ClientManager.createClient();
         StringBuilder wsUrl = new StringBuilder();
-        wsUrl.append("ws://").append(baseUrl.getHost()).append(":").
-                append(baseUrl.getPort()).append(baseUrl.getPath()).append("echo");
+        wsUrl.append("ws://")
+             .append(baseUrl.getHost())
+             .append(":")
+             .append(baseUrl.getPort())
+             .append(baseUrl.getPath())
+             .append("echo");
+
         client.connectToServer(this, new URI(wsUrl.toString()));
+
         countDown.await(100, TimeUnit.SECONDS);
         assertEquals("ECHO", buffer.toString());
     }

--- a/focused/websocket/encoderDecoder/src/test/java/jakartaee/examples/websocket/encoderdecoder/EncoderDecoderEndpointIT.java
+++ b/focused/websocket/encoderDecoder/src/test/java/jakartaee/examples/websocket/encoderdecoder/EncoderDecoderEndpointIT.java
@@ -1,5 +1,5 @@
 /*
- * Permission to use, copy, modify, and/or distribute this software for any 
+ * Permission to use, copy, modify, and/or distribute this software for any
  * purpose with or without fee is hereby granted.
  *
  * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR(S) DISCLAIMS ALL WARRANTIES
@@ -13,27 +13,27 @@
 package jakartaee.examples.websocket.encoderdecoder;
 
 
-import java.io.File;
+import static org.junit.Assert.assertEquals;
+
 import java.io.IOException;
 import java.net.URI;
 import java.net.URL;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+
+import org.glassfish.tyrus.client.ClientManager;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
 import jakarta.websocket.ClientEndpoint;
 import jakarta.websocket.EncodeException;
 import jakarta.websocket.OnMessage;
 import jakarta.websocket.OnOpen;
 import jakarta.websocket.Session;
-import org.jboss.arquillian.junit.Arquillian;
-import org.glassfish.tyrus.client.ClientManager;
-import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.container.test.api.RunAsClient;
-import org.jboss.arquillian.test.api.ArquillianResource;
-import static org.jboss.shrinkwrap.api.ShrinkWrap.create;
-import org.jboss.shrinkwrap.api.spec.WebArchive;
-import static org.junit.Assert.assertEquals;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import jakartaee.examples.utils.ITBase;
 
 /**
  * An annotated ClientEndpoint for the annotated ClientEndpoint example.
@@ -41,12 +41,11 @@ import org.junit.runner.RunWith;
  * @author Manfred Riem (mriem@manorrock.com)
  */
 @ClientEndpoint(
-        encoders = {EncoderDecoderEncoder.class},
-        decoders = {EncoderDecoderDecoder.class}
+    encoders = EncoderDecoderEncoder.class,
+    decoders = EncoderDecoderDecoder.class
 )
 @RunWith(Arquillian.class)
-
-public class EncoderDecoderEndpointTest {
+public class EncoderDecoderEndpointIT extends ITBase {
 
     /**
      * Stores the base URL.
@@ -63,22 +62,6 @@ public class EncoderDecoderEndpointTest {
      * Stores our countdown latch.
      */
     private CountDownLatch countDown = new CountDownLatch(1);
-
-    /**
-     * Create the deployment web archive.
-     *
-     * @return the deployment web archive.
-     */
-    @Deployment
-    public static WebArchive createDeployment() {
-        return create(WebArchive.class).addClasses(
-                EncoderDecoderEndpoint.class, EncoderDecoder.class,
-                EncoderDecoderDecoder.class, EncoderDecoderEncoder.class).
-                addAsWebResource(new File("src/main/webapp/index.xhtml")).
-                addAsWebInfResource(new File("src/main/webapp/WEB-INF/web.xml")).
-                addAsWebInfResource(new File("src/main/webapp/WEB-INF/beans.xml"))
-                ;
-    }
 
     /**
      * Get the buffer.
@@ -99,7 +82,7 @@ public class EncoderDecoderEndpointTest {
         try {
             session.getBasicRemote().sendObject(new EncoderDecoder("ECHO"));
         } catch (IOException | EncodeException e) {
-            buffer.append(e.getMessage()); 
+            buffer.append(e.getMessage());
         }
     }
 
@@ -124,12 +107,20 @@ public class EncoderDecoderEndpointTest {
     @RunAsClient
     public void testClientEndpoint() throws Exception {
         countDown = new CountDownLatch(1);
+
         ClientManager client = ClientManager.createClient();
         StringBuilder wsUrl = new StringBuilder();
-        wsUrl.append("ws://").append(baseUrl.getHost()).append(":").
-                append(baseUrl.getPort()).append(baseUrl.getPath()).append("echo");
+        wsUrl.append("ws://")
+             .append(baseUrl.getHost())
+             .append(":")
+             .append(baseUrl.getPort())
+             .append(baseUrl.getPath())
+             .append("echo");
+
         client.connectToServer(this, new URI(wsUrl.toString()));
+
         countDown.await(100, TimeUnit.SECONDS);
+
         assertEquals("ECHO", buffer.toString());
     }
 }

--- a/focused/websocket/onClose/src/test/java/jakartaee/examples/websocket/onclose/OnCloseEndpointIT.java
+++ b/focused/websocket/onClose/src/test/java/jakartaee/examples/websocket/onclose/OnCloseEndpointIT.java
@@ -1,5 +1,5 @@
 /*
- * Permission to use, copy, modify, and/or distribute this software for any 
+ * Permission to use, copy, modify, and/or distribute this software for any
  * purpose with or without fee is hereby granted.
  *
  * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR(S) DISCLAIMS ALL WARRANTIES
@@ -10,37 +10,38 @@
  * OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
  * CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
-package jakartaee.examples.websocket.onopen;
+package jakartaee.examples.websocket.onclose;
 
 
-import java.io.File;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
 import java.net.URI;
 import java.net.URL;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
-import jakarta.websocket.ClientEndpoint;
-import jakarta.websocket.OnMessage;
-import jakarta.websocket.Session;
-import org.jboss.arquillian.junit.Arquillian;
+
 import org.glassfish.tyrus.client.ClientManager;
-import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
-import static org.jboss.shrinkwrap.api.ShrinkWrap.create;
-import org.jboss.shrinkwrap.api.spec.WebArchive;
-import static org.junit.Assert.assertTrue;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import jakarta.websocket.ClientEndpoint;
+import jakarta.websocket.OnClose;
+import jakarta.websocket.OnMessage;
+import jakarta.websocket.Session;
+import jakartaee.examples.utils.ITBase;
+
 /**
- * A JUnit test for the @OnOpen example.
+ * A JUnit test for the @OnError example.
  *
  * @author Manfred Riem (mriem@manorrock.com)
  */
 @ClientEndpoint
 @RunWith(Arquillian.class)
-
-public class OnOpenEndpointTest {
+public class OnCloseEndpointIT extends ITBase {
 
     /**
      * Stores the base URL.
@@ -59,21 +60,6 @@ public class OnOpenEndpointTest {
     private CountDownLatch countDown = new CountDownLatch(1);
 
     /**
-     * Create the deployment web archive.
-     *
-     * @return the deployment web archive.
-     */
-    @Deployment
-    public static WebArchive createDeployment() {
-        return create(WebArchive.class).addClasses(
-                OnOpenEndpoint.class).
-                addAsWebResource(new File("src/main/webapp/index.xhtml")).
-                addAsWebInfResource(new File("src/main/webapp/WEB-INF/web.xml")).
-                addAsWebInfResource(new File("src/main/webapp/WEB-INF/beans.xml"))
-                ;
-    }
-
-    /**
      * Get the buffer.
      *
      * @return the buffer.
@@ -87,10 +73,22 @@ public class OnOpenEndpointTest {
      *
      * @param session the session.
      * @param message the message.
+     * @throws Exception when a serious error occurs.
      */
     @OnMessage
-    public void onMessage(Session session, String message) {
-        buffer.append(message);
+    public void onMessage(Session session, String message) throws Exception {
+        session.getBasicRemote().sendText(message);
+    }
+
+    /**
+     * Handle the onClose.
+     *
+     * @param session the session.
+     * @throws IOException when an I/O error occurs.
+     */
+    @OnClose
+    public void onClose(Session session) throws IOException {
+        buffer.append("Closing connection");
         countDown.countDown();
     }
 
@@ -103,12 +101,20 @@ public class OnOpenEndpointTest {
     @RunAsClient
     public void testClientEndpoint() throws Exception {
         countDown = new CountDownLatch(1);
+
         ClientManager client = ClientManager.createClient();
         StringBuilder wsUrl = new StringBuilder();
-        wsUrl.append("ws://").append(baseUrl.getHost()).append(":").
-                append(baseUrl.getPort()).append(baseUrl.getPath()).append("echo");
+        wsUrl.append("ws://")
+             .append(baseUrl.getHost())
+             .append(":")
+             .append(baseUrl.getPort())
+             .append(baseUrl.getPath())
+             .append("echo");
+
         client.connectToServer(this, new URI(wsUrl.toString()));
-        countDown.await(100, TimeUnit.SECONDS);
-        assertTrue(buffer.toString().contains("Session started at "));
+
+        countDown.await(10, SECONDS);
+        System.out.println(buffer.toString());
+        assertTrue(buffer.toString().contains("Closing connection"));
     }
 }

--- a/focused/websocket/onError/src/test/java/jakartaee/examples/websocket/onerror/OnErrorEndpointIT.java
+++ b/focused/websocket/onError/src/test/java/jakartaee/examples/websocket/onerror/OnErrorEndpointIT.java
@@ -1,5 +1,5 @@
 /*
- * Permission to use, copy, modify, and/or distribute this software for any 
+ * Permission to use, copy, modify, and/or distribute this software for any
  * purpose with or without fee is hereby granted.
  *
  * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR(S) DISCLAIMS ALL WARRANTIES
@@ -10,39 +10,37 @@
  * OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
  * CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
-package jakartaee.examples.websocket.annotatedclientendpoint;
+package jakartaee.examples.websocket.onerror;
 
-import java.io.File;
-import java.io.IOException;
+
+import static org.junit.Assert.assertTrue;
+
 import java.net.URI;
 import java.net.URL;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
-import jakarta.websocket.ClientEndpoint;
-import jakarta.websocket.OnMessage;
-import jakarta.websocket.OnOpen;
-import jakarta.websocket.Session;
-import org.glassfish.tyrus.client.ClientManager;
-import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.container.test.api.RunAsClient;
 
+import org.glassfish.tyrus.client.ClientManager;
+import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
-import static org.jboss.shrinkwrap.api.ShrinkWrap.create;
-import org.jboss.shrinkwrap.api.spec.WebArchive;
-import static org.junit.Assert.assertEquals;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import jakarta.websocket.ClientEndpoint;
+import jakarta.websocket.OnError;
+import jakarta.websocket.OnMessage;
+import jakarta.websocket.Session;
+import jakartaee.examples.utils.ITBase;
+
 /**
- * An annotated ClientEndpoint for the annotated ClientEndpoint example.
+ * A JUnit test for the @OnError example.
  *
  * @author Manfred Riem (mriem@manorrock.com)
  */
 @ClientEndpoint
 @RunWith(Arquillian.class)
-
-public class AnnotatedClientEndpointTest {
+public class OnErrorEndpointIT extends ITBase {
 
     /**
      * Stores the base URL.
@@ -61,21 +59,6 @@ public class AnnotatedClientEndpointTest {
     private CountDownLatch countDown = new CountDownLatch(1);
 
     /**
-     * Create the deployment web archive.
-     *
-     * @return the deployment web archive.
-     */
-    @Deployment
-    public static WebArchive createDeployment() {
-        return create(WebArchive.class).addClasses(
-                AnnotatedClientEndpointServerEndpoint.class).
-                addAsWebResource(new File("src/main/webapp/index.xhtml")).
-                addAsWebInfResource(new File("src/main/webapp/WEB-INF/web.xml")).
-                addAsWebInfResource(new File("src/main/webapp/WEB-INF/beans.xml"))
-                ;
-    }
-
-    /**
      * Get the buffer.
      *
      * @return the buffer.
@@ -85,17 +68,14 @@ public class AnnotatedClientEndpointTest {
     }
 
     /**
-     * Handle the on open event.
+     * Handle the OnError.
      *
-     * @param session the session.
+     * @param cause the cause.
      */
-    @OnOpen
-    public void onOpen(Session session) {
-        try {
-            session.getBasicRemote().sendText("ECHO");
-        } catch (IOException ioe) {
-            buffer.append(ioe.getMessage());
-        }
+    @OnError
+    public void onError(Throwable cause) {
+        buffer.append(cause.getMessage());
+        countDown.countDown();
     }
 
     /**
@@ -103,11 +83,12 @@ public class AnnotatedClientEndpointTest {
      *
      * @param session the session.
      * @param message the message.
+     * @throws Exception when a serious error occurs.
      */
     @OnMessage
-    public void onMessage(Session session, String message) {
-        buffer.append(message);
-        countDown.countDown();
+    public void onMessage(Session session, String message) throws Exception {
+        session.close();
+        session.getBasicRemote().sendText(message);
     }
 
     /**
@@ -125,6 +106,7 @@ public class AnnotatedClientEndpointTest {
                 append(baseUrl.getPort()).append(baseUrl.getPath()).append("echo");
         client.connectToServer(this, new URI(wsUrl.toString()));
         countDown.await(100, TimeUnit.SECONDS);
-        assertEquals("ECHO", buffer.toString());
+        System.out.println(buffer.toString());
+        assertTrue(buffer.toString().contains("The connection has been closed."));
     }
 }


### PR DESCRIPTION
WebSocket tests now use the war build by the example module, so that war, and the war used by the tests is exactly the same. This should be easier for beginners to understand and reason about.